### PR TITLE
#14 Code blocks in readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -59,6 +59,7 @@ Show content only if a user has active licenses
 `[edd_has_active_licenses] Content Here [/edd_has_active_licenses]`
 
 Show content only if user has expired licenses
+
 `[edd_has_expired_licenses]Content Here[/edd_has_expired_licenses]`
 
 == Changelog ==

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ Show if the user has made previous purchases (will always be hidden if logged ou
 Show only if the user has no purchases. Includes the 'loggedout' parameter to specify if logged out users
 should be included in seeing the content. (Default true)
 
-`[edd_user_has_no_purchases loggedout=true] Content Here [/edd_user_has_no_purchases]`
+`[edd_user_has_no_purchases loggedout="true"] Content Here [/edd_user_has_no_purchases]`
 
 Show content only if a user is logged in
 
@@ -53,7 +53,8 @@ Supports multiple IDs. If a download has variable pricing, you can pass just the
 
 `[edd_user_has_purchased ids="20,34,25:1"] Content Here [/edd_user_has_purchased]`
 
-Software Licensing Support:
+**Software Licensing Support:**
+
 Show content only if a user has active licenses
 
 `[edd_has_active_licenses] Content Here [/edd_has_active_licenses]`

--- a/readme.txt
+++ b/readme.txt
@@ -11,43 +11,55 @@ Add additional shortcodes for Easy Digital Downloads
 
 == Description ==
 
-As simple as it sounds. Adds some additional shortcodes to the Easy Digital Downloads plugin. The shortcodes included all need opening and closing tags:
+This plugin is as simple as it sounds. It adds some additional shortcodes to the Easy Digital Downloads plugin. The shortcodes included all need opening and closing tags:
 
 Show only if the cart has items in it
-[edd_cart_has_contents]Content Here[/edd_cart_has_contents]
+
+`[edd_cart_has_contents] Content Here [/edd_cart_has_contents]`
 
 Show only if the cart is empty
-[edd_cart_is_empty]Content Here[/edd_cart_is_empty]
+
+`[edd_cart_is_empty] Content Here [/edd_cart_is_empty]`
 
 Show only if the cart contains any/all of the specified items
-[edd_items_in_cart ids="20"]Content Here[/edd_items_in_cart]
-[edd_items_in_cart ids="20,34,25:1"]Content Here[/edd_items_in_cart]
-[edd_items_in_cart ids="20,34,25:1" match="all"]Content Here[/edd_items_in_cart]
-[edd_items_in_cart ids="20,34,25:1" match="any"]Content Here[/edd_items_in_cart]
+
+`[edd_items_in_cart ids="20"] Content Here [/edd_items_in_cart]`
+
+`[edd_items_in_cart ids="20,34,25:1"] Content Here [/edd_items_in_cart]`
+
+`[edd_items_in_cart ids="20,34,25:1" match="all"] Content Here [/edd_items_in_cart]`
+
+`[edd_items_in_cart ids="20,34,25:1" match="any"] Content Here [/edd_items_in_cart]`
 
 Show if the user has made previous purchases (will always be hidden if logged out)
-[edd_user_has_purchases]Content Here[/edd_user_has_purchases]
+
+`[edd_user_has_purchases] Content Here [/edd_user_has_purchases]`
 
 Show only if the user has no purchases. Includes the 'loggedout' parameter to specify if logged out users
 should be included in seeing the content. (Default true)
-[edd_user_has_no_purchases loggedout=true]Content Here[/edd_user_has_no_purchases]
+
+`[edd_user_has_no_purchases loggedout=true] Content Here [/edd_user_has_no_purchases]`
 
 Show content only if a user is logged in
-[edd_is_user_logged_in]Content Here[/edd_is_user_logged_in]
+
+`[edd_is_user_logged_in] Content Here [/edd_is_user_logged_in]`
 
 Show content only if a user is logged out
-[edd_is_user_logged_out]Content Here[/edd_is_user_logged_out]
+
+`[edd_is_user_logged_out] Content Here [/edd_is_user_logged_out]`
 
 Show content only if a user has purchased any of the specified download ids.
-Supports multiple IDs. If a download has variable pricing, you can pass just the ID for all options, or <download id>:<price id> for a specific variable pricing option.
-[edd_user_has_purchased ids="20,34,25:1"]Content Here[/edd_user_has_purchased]
+Supports multiple IDs. If a download has variable pricing, you can pass just the ID for all options, or `<download id>`:`<price id>` for a specific variable pricing option.
+
+`[edd_user_has_purchased ids="20,34,25:1"] Content Here [/edd_user_has_purchased]`
 
 Software Licensing Support:
 Show content only if a user has active licenses
-[edd_has_active_licenses]Content Here[/edd_has_active_licenses]
+
+`[edd_has_active_licenses] Content Here [/edd_has_active_licenses]`
 
 Show content only if user has expired licenses
-[edd_has_expired_licenses]Content Here[/edd_has_expired_licenses]
+`[edd_has_expired_licenses]Content Here[/edd_has_expired_licenses]`
 
 == Changelog ==
 = 1.4 - February 24, 2017 =


### PR DESCRIPTION
Fixes #14 

Proposed Changes:
1. Place shortcodes in code blocks
2. Update first paragraph to use complete sentences
3. Other formatting.  I made some guesses about how we want this to look.  I put each code block on its own line under the description and put a space around the `Content Here` for readability.  I also contemplated adding a `:` after each description, but I thought I'd let y'all weigh in on that one.

Let me know if there is a different way you want this to look.
