### PR TITLE
Change plugins_loaded priority

### DIFF
--- a/edd-additional-shortcodes.php
+++ b/edd-additional-shortcodes.php
@@ -107,4 +107,4 @@ class EDD_Additional_Shortcodes {
 function edd_additional_shortcodes() {
 	return EDD_Additional_Shortcodes::instance();
 }
-add_action( 'plugins_loaded', 'edd_additional_shortcodes' );
+add_action( 'plugins_loaded', 'edd_additional_shortcodes', 100 );


### PR DESCRIPTION
Fixes #17

This makes this extension compatible with Software Licensing 3.8 by making sure the additional shortcodes are loaded after Software Licensing.