### PR TITLE
Release/1.4.1

### DIFF
--- a/edd-additional-shortcodes.php
+++ b/edd-additional-shortcodes.php
@@ -1,12 +1,12 @@
 <?php
 /*
-Plugin Name: Easy Digital Downloads - Additional Shortcodes
-Plugin URI: https://easydigitaldownloads.com/downloads/edd-additional-shortcodes/
-Description: Adds additional shortcodes to EDD
-Version: 1.4
-Author: Easy Digital Downloads
-Author URI: https://easydigitaldownloads.com
-Text Domain: edd-asc-txt
+ * Plugin Name: Easy Digital Downloads - Additional Shortcodes
+ * Plugin URI: https://easydigitaldownloads.com/downloads/edd-additional-shortcodes/
+ * Description: Adds additional shortcodes to Easy Digital Downloads.
+ * Version: 1.4
+ * Author: Sandhills Development, LLC
+ * Author URI: https://sandhillsdev.com
+ * Text Domain: edd-asc-txt
 */
 
 if ( ! defined ( 'ABSPATH' ) ) {

--- a/edd-additional-shortcodes.php
+++ b/edd-additional-shortcodes.php
@@ -107,4 +107,4 @@ class EDD_Additional_Shortcodes {
 function edd_additional_shortcodes() {
 	return EDD_Additional_Shortcodes::instance();
 }
-add_action( 'plugins_loaded', 'edd_additional_shortcodes' );
+add_action( 'plugins_loaded', 'edd_additional_shortcodes', 100 );

--- a/edd-additional-shortcodes.php
+++ b/edd-additional-shortcodes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Digital Downloads - Additional Shortcodes
  * Plugin URI: https://easydigitaldownloads.com/downloads/edd-additional-shortcodes/
  * Description: Adds additional shortcodes to Easy Digital Downloads.
- * Version: 1.4
+ * Version: 1.4.1
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
  * Text Domain: edd-asc-txt
@@ -61,7 +61,7 @@ class EDD_Additional_Shortcodes {
 		 * @since 1.4
 		 */
 		private function properties() {
-			self::$instance->version = '1.4';
+			self::$instance->version = '1.4.1';
 			self::$instance->plugin_dir = trailingslashit( plugin_dir_path( __FILE__ ) );
 			self::$instance->plugin_url = trailingslashit( plugin_dir_url( __FILE__ ) );
 		}

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -46,13 +46,13 @@ class EDD_Additional_Shortcodes_Core {
 				$matches++;
 
 				if ( 'any' === strtolower( $match ) ) {
-					return $content;
+					return edd_additional_shortcodes()->maybe_do_shortcode( $content );
 				}
 			}
 		}
 
 		if ( 'all' === strtolower( $match ) && count( $downloads ) === $matches ) {
-			return $content;
+			return edd_additional_shortcodes()->maybe_do_shortcode( $content );
 		}
 
 		return '';
@@ -63,14 +63,14 @@ class EDD_Additional_Shortcodes_Core {
 			return edd_additional_shortcodes()->maybe_do_shortcode( $content );
 		}
 	}
-	
+
 	function user_has_purchases( $attributes, $content = null ) {
 		$user_id = get_current_user_id();
 		if ( edd_has_purchases( $user_id ) ) {
 			return edd_additional_shortcodes()->maybe_do_shortcode( $content );
 		}
 	}
-	
+
 	function user_has_purchased( $attributes, $content = null ) {
 		$args      = shortcode_atts( array( 'ids' => '' ), $attributes, 'edd_user_has_purchased' );
 		$downloads = explode( ',', str_replace( ' ', '', $args['ids'] ) );
@@ -94,13 +94,13 @@ class EDD_Additional_Shortcodes_Core {
 				$has_purchased = edd_has_user_purchased( $user_id, $download );
 			}
 			if ( $has_purchased ) {
-				return $content;
+				return edd_additional_shortcodes()->maybe_do_shortcode( $content );
 			}
 		}
 
 		return '';
 	}
-	
+
 	function user_has_no_purchases( $attributes, $content = null ) {
 		$args = shortcode_atts( array( 'loggedout' => 'true' ), $attributes, 'edd_user_has_no_purchases' );
 
@@ -113,7 +113,7 @@ class EDD_Additional_Shortcodes_Core {
 		if ( !edd_has_purchases( $user_id ) )
 			return edd_additional_shortcodes()->maybe_do_shortcode( $content );
 	}
-	
+
 	function is_user_logged_in( $attributes, $content = null ) {
 		if ( ! is_user_logged_in() ) {
 			return '';

--- a/readme.txt
+++ b/readme.txt
@@ -11,43 +11,57 @@ Add additional shortcodes for Easy Digital Downloads
 
 == Description ==
 
-As simple as it sounds. Adds some additional shortcodes to the Easy Digital Downloads plugin. The shortcodes included all need opening and closing tags:
+This plugin is as simple as it sounds. It adds some additional shortcodes to the Easy Digital Downloads plugin. The shortcodes included all need opening and closing tags:
 
 Show only if the cart has items in it
-[edd_cart_has_contents]Content Here[/edd_cart_has_contents]
+
+`[edd_cart_has_contents] Content Here [/edd_cart_has_contents]`
 
 Show only if the cart is empty
-[edd_cart_is_empty]Content Here[/edd_cart_is_empty]
+
+`[edd_cart_is_empty] Content Here [/edd_cart_is_empty]`
 
 Show only if the cart contains any/all of the specified items
-[edd_items_in_cart ids="20"]Content Here[/edd_items_in_cart]
-[edd_items_in_cart ids="20,34,25:1"]Content Here[/edd_items_in_cart]
-[edd_items_in_cart ids="20,34,25:1" match="all"]Content Here[/edd_items_in_cart]
-[edd_items_in_cart ids="20,34,25:1" match="any"]Content Here[/edd_items_in_cart]
+
+`[edd_items_in_cart ids="20"] Content Here [/edd_items_in_cart]`
+
+`[edd_items_in_cart ids="20,34,25:1"] Content Here [/edd_items_in_cart]`
+
+`[edd_items_in_cart ids="20,34,25:1" match="all"] Content Here [/edd_items_in_cart]`
+
+`[edd_items_in_cart ids="20,34,25:1" match="any"] Content Here [/edd_items_in_cart]`
 
 Show if the user has made previous purchases (will always be hidden if logged out)
-[edd_user_has_purchases]Content Here[/edd_user_has_purchases]
+
+`[edd_user_has_purchases] Content Here [/edd_user_has_purchases]`
 
 Show only if the user has no purchases. Includes the 'loggedout' parameter to specify if logged out users
 should be included in seeing the content. (Default true)
-[edd_user_has_no_purchases loggedout=true]Content Here[/edd_user_has_no_purchases]
+
+`[edd_user_has_no_purchases loggedout="true"] Content Here [/edd_user_has_no_purchases]`
 
 Show content only if a user is logged in
-[edd_is_user_logged_in]Content Here[/edd_is_user_logged_in]
+
+`[edd_is_user_logged_in] Content Here [/edd_is_user_logged_in]`
 
 Show content only if a user is logged out
-[edd_is_user_logged_out]Content Here[/edd_is_user_logged_out]
+
+`[edd_is_user_logged_out] Content Here [/edd_is_user_logged_out]`
 
 Show content only if a user has purchased any of the specified download ids.
-Supports multiple IDs. If a download has variable pricing, you can pass just the ID for all options, or <download id>:<price id> for a specific variable pricing option.
-[edd_user_has_purchased ids="20,34,25:1"]Content Here[/edd_user_has_purchased]
+Supports multiple IDs. If a download has variable pricing, you can pass just the ID for all options, or `<download id>`:`<price id>` for a specific variable pricing option.
 
-Software Licensing Support:
+`[edd_user_has_purchased ids="20,34,25:1"] Content Here [/edd_user_has_purchased]`
+
+**Software Licensing Support:**
+
 Show content only if a user has active licenses
-[edd_has_active_licenses]Content Here[/edd_has_active_licenses]
+
+`[edd_has_active_licenses] Content Here [/edd_has_active_licenses]`
 
 Show content only if user has expired licenses
-[edd_has_expired_licenses]Content Here[/edd_has_expired_licenses]
+
+`[edd_has_expired_licenses]Content Here[/edd_has_expired_licenses]`
 
 == Changelog ==
 = 1.4 - February 24, 2017 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: easydigitaldownloads, cklosows
 Tags: Easy Digital Downloads, Shortcodes
 Requires at least: 3.0
 Tested up to: 5.8
-Stable tag: 1.4
+Stable tag: 1.4.1
 Donate link: https://easydigitaldownloads.com/donate/
 License: GPLv2 or later
 
@@ -64,6 +64,11 @@ Show content only if user has expired licenses
 `[edd_has_expired_licenses]Content Here[/edd_has_expired_licenses]`
 
 == Changelog ==
+= 1.4.1 - September 2, 2021 =
+* Fix: Compatibility with Software Licensing 3.8.
+* Fix: Use 'maybe_do_shortcode' to allow for nested shortcodes.
+* Tweak: Improve readme.txt formatting to make examples more readable.
+
 = 1.4 - February 24, 2017 =
 * NEW: Add support for Software Licensing.
 * NEW: Add support for specific items in the cart.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: easydigitaldownloads, cklosows
 Tags: Easy Digital Downloads, Shortcodes
 Requires at least: 3.0
-Tested up to: 4.7
+Tested up to: 5.8
 Stable tag: 1.4
 Donate link: https://easydigitaldownloads.com/donate/
 License: GPLv2 or later


### PR DESCRIPTION
https://github.com/easydigitaldownloads/edd-additional-shortcodes/milestone/2?closed=1

| Issue # | Description |
|---------|-------------|
| #17 | Software Licensing shortcodes do not work with SL 3.8 |
| #14 | Improve readme formatting -- put shortcode examples in code blocks |
| #13 | Push an update for compatibility with latest WP |
| #10 | Use the maybe_do_shortcode function in the edd_items_in_cart shortcode |